### PR TITLE
Unrestore cut enemy sounds

### DIFF
--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -431,11 +431,11 @@ SEC_GAME void A_Look (mobj_t *actor) // 80011340
         case sfx_possit1://sfx_posit1:
         case sfx_possit2://sfx_posit2:
         case sfx_possit3://sfx_posit3:
-            sound = sfx_possit1+P_Random()%3; // [Immorpher] integer rounding to have 0,1,2 and restore missing sounds
+            sound = sfx_possit1 + (P_Random() & 1);
             break;
         case sfx_impsit1://sfx_bgsit1:
         case sfx_impsit2://sfx_bgsit2:
-            sound = sfx_impsit1+(P_Random()&1);
+            sound = sfx_impsit1 + (P_Random() & 1);
             break;
         default:
             sound = actor->info->seesound;
@@ -595,12 +595,12 @@ SEC_GAME void A_Scream (mobj_t *actor) // 80011740
     case sfx_posdie1://sfx_podth1:
     case sfx_posdie2://sfx_podth2:
     case sfx_posdie3://sfx_podth3:
-        sound = sfx_posdie1 + P_Random()%3; // [Immorpher] now the third death sound happens given integer rounding
+        sound = sfx_posdie1 + (P_Random() & 1);
         break;
 
     case sfx_impdth1://sfx_bgdth1:
     case sfx_impdth2://sfx_bgdth2:
-        sound = sfx_impdth1 + (P_Random ()&1);
+        sound = sfx_impdth1 + (P_Random() & 1);
         break;
 
     default:


### PR DESCRIPTION
Earlier discussion at https://github.com/azamorapl/doom64-complete-edition/issues/3 and DOOM 64 Discord.

Unrestores cut enemy sounds, matching PsyDoom's decision. Marking as draft in case a more complex solution that lets players choose whether the sounds play or not is desired.